### PR TITLE
fix: Removed 'darwin.apple_sdk_11_0.callPackage'

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -1,8 +1,6 @@
 # This was mostly copied from gomod2nix :)
 final: prev: let
-  # The newer Darwin SDK does not exist in current (nixos-22.05) stable
-  # branches, so just fallback to the default callPackage.
-  callPackage = final.darwin.apple_sdk_11_0.callPackage or final.callPackage;
+  callPackage = final.callPackage;
 in {
   inherit (callPackage ./builder {}) buildGleamApplication;
 }


### PR DESCRIPTION
When I tried to build my gleam app with this library I got an error referring to the removal of `darwin.apple_sdk_11_0.callPackage`.

I'm still a bit uncertain if there is an issue with me removing this but at least when looking at the `gomod2nix` inspiration it seems to be the correct thing to do.

I tested this with various `nixpkgs` (`nixos-unstable`, `nixos-25.05`, `nixpkgs-25-05-darwin`) and for my app they all built without issue on `aarch64-darwin` and `x86-64-linux`.

But maybe I didn't test the right thing as I still don't quite understand what the initial problem was.
I thought I'll open this pull request in order to get this fixed faster **if** this is the right fix.

It was removed in `gomod2nix` as well with this commit:

https://github.com/nix-community/gomod2nix/commit/bf376bd322ec9c84f6bec75d78aa0b3544cc8049