### PR TITLE
handle name prefix collisions in localPackages better

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -109,8 +109,8 @@ in {
         postPatch =
           lib.concatMapStringsSep "\n" (
             p: ''
-              sed -i -e 's|${p.path}|${p.newPath}|g' manifest.toml
-              sed -i -e 's|${p.path}|${p.newPath}|g' gleam.toml
+              sed -i -e 's|"${p.path}"|"${p.newPath}"|g' manifest.toml
+              sed -i -e 's|"${p.path}"|"${p.newPath}"|g' gleam.toml
             ''
           )
           localDeps;


### PR DESCRIPTION
given a structure of local packages like:
```
./src/some
./src/some_web
./src/some_server
```
where `some_server` depends on `some_web` and `some`
The old code would replace `some_web` with the path to the `some`.
This fix simply ensures that we always replace full package names instead of partial ones.