### PR TITLE
fix localPackages by staging local deps in writable paths

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -73,9 +73,10 @@ in {
       # Build a lookup attrset for local packages.
       localDerivs = lib.mergeAttrsList (map (
           p: let
-            name = (fromTOML (readFile (p + "/gleam.toml"))).name;
+            localSrc = p;
+            name = (fromTOML (readFile (localSrc + "/gleam.toml"))).name;
           in {
-            "${name}" = p;
+            "${name}" = localSrc;
           }
         )
         localPackages);
@@ -83,10 +84,12 @@ in {
       map (
         p: {
           inherit (p) name path;
-          newPath =
+          localSrc =
             if localDerivs ? "${p.name}"
             then localDerivs.${p.name}
             else builtins.throw "Local dependency \"${p.name}\" not found in `localPackages`.";
+          # Keep local packages in a writable location during build.
+          newPath = p.path;
         }
       ) (filterPackagesBySource "local" manifestToml.packages);
 
@@ -106,14 +109,7 @@ in {
 
         src = lib.cleanSource attrs.src;
 
-        postPatch =
-          lib.concatMapStringsSep "\n" (
-            p: ''
-              sed -i -e 's|"${p.path}"|"${p.newPath}"|g' manifest.toml
-              sed -i -e 's|"${p.path}"|"${p.newPath}"|g' gleam.toml
-            ''
-          )
-          localDeps;
+        postPatch = attrs.postPatch or null;
 
         # Here we must copy the dependencies into the right spot and
         # create a packages.toml file so the gleam compiler does not
@@ -129,6 +125,22 @@ in {
             cat <<EOF > build/packages/packages.toml
             ${packagesTOML}
             EOF
+
+            ${
+              lib.concatStringsSep "\n" (
+                lib.forEach localDeps (
+                  d: ''
+                    mkdir -p "$(dirname "${d.newPath}")"
+                    mkdir -p "${d.newPath}"
+                    rsync --chmod=Du=rwx,Dg=rx,Do=rx,Fu=rw,Fg=r,Fo=r -r ${d.localSrc}/* "${d.newPath}/"
+
+                    # A local dependency fingerprint file newer than gleam.toml
+                    # avoids forcing dependency resolution in Gleam.
+                    echo "0" > "build/packages/${d.name}.config_fingerprint"
+                  ''
+                )
+              )
+            }
 
             ${
               lib.concatStringsSep "\n" (
@@ -150,6 +162,19 @@ in {
                 ''
               )
             )}
+
+            # Prime local package dependency caches so they do not try to fetch.
+            ${
+              lib.concatStringsSep "\n" (
+                lib.forEach localDeps (
+                  d: ''
+                    mkdir -p "${d.newPath}/build/packages"
+                    cp build/packages/packages.toml "${d.newPath}/build/packages/packages.toml"
+                    rsync --chmod=Du=rwx,Dg=rx,Do=rx,Fu=rw,Fg=r,Fo=r -r build/packages/* "${d.newPath}/build/packages/"
+                  ''
+                )
+              )
+            }
 
             runHook postConfigure
           '';


### PR DESCRIPTION
This fixes #7.
As I last suspected, it seemed to be a problem with the local packages in general, not git.

This fix was entirely generated by AI, I only took a brief look at the changes (I am not too experienced at nix).
Hence, the draft pull request.

I am planning on reviewing this later (or let a friend review it).
Wanted to create a PR anyway, to share the fix.

<details>
<summary> Ai's summary </summary>

### ✅ What I changed

 #### nix-gleam/builder/default.nix

 I changed local package handling so Gleam does not try to fetch in sandbox:

 1. Stop rewriting local paths to /nix/store/...
     - Removed the automatic postPatch that replaced ../shogg with an immutable store
 path.
     - Kept postPatch overridable via attrs.postPatch.
 2. Stage localPackages into writable build paths
     - For each source = "local" dep from manifest.toml, copy the local package source
 into the dependency path (p.path, e.g. ../shogg) inside build workspace.
     - This keeps local package path semantics while staying writable.
 3. Prime local package cache metadata
     - Create build/packages/<name>.config_fingerprint for local deps.
     - Copy/sync prepared package cache into each local package’s build/packages/ so Gleam
 doesn’t re-resolve online.
 
 </details>