### PR TITLE
Fix the typo of preBuild

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -166,7 +166,7 @@ in {
         buildPhase =
           attrs.buildPhase
           or ''
-            runHook prebuild
+            runHook preBuild
 
             export REBAR_CACHE_DIR="$TMP/.rebar-cache"
 


### PR DESCRIPTION
I think it is `preBuild` (in camel-case), not `prebuild`.