### PR TITLE
Add support for local deps in Gleam 1.15+

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   git,
+  xxhash,
   fetchHex,
   gleam,
   erlang,
@@ -96,7 +97,7 @@ in {
     needsElixir = with lib; any isElixirProject manifestToml.packages;
 
     # nativeBuildInputs needed for both targets.
-    defaultNativeBuildInputs = [gleam beamPackages.hex rsync git];
+    defaultNativeBuildInputs = [gleam beamPackages.hex rsync git xxhash];
   in
     # Base common mkDerivation attributes
     stdenv.mkDerivation (attrs
@@ -149,6 +150,14 @@ in {
                   rsync --chmod=Du=rwx,Dg=rx,Do=rx,Fu=rw,Fg=r,Fo=r -r ${d.derivation}/* build/packages/${d.name}/
                 ''
               )
+            )}
+
+            # To prevent dependency resolution in Gleam 1.15+, local packages
+            # need to have their fingerprint up-to-date.
+            ${lib.concatStringsSep "\n" (
+              lib.forEach localDeps (d: ''
+                printf "%u" 0x$(xxhsum -H3 ${d.newPath}/gleam.toml | cut -d' ' -f1 | cut -d '_' -f2) > build/packages/${d.name}.config_fingerprint
+              '')
             )}
 
             runHook postConfigure


### PR DESCRIPTION
Since Gleam 1.15, the gleam.toml file for path dependencies is checked for any changes that would need a new resolution step, as implemented in https://github.com/gleam-lang/gleam/commit/0b5c27ddcb18031aec7afd5f14e9fc761ccd5193.

As Nix builds are sandboxed, the dependency resolution fails. To circumvent this, generate a gleam.toml file fingerprint using xxhsum, so that the Gleam build tool's dependency resolution code thinks the local packages are up-to-date.

Tested manually on a Lustre monorepo (roughly the same as what's described in #3).